### PR TITLE
Resync locations with documented allowed locations

### DIFF
--- a/src/TaskParameters.ts
+++ b/src/TaskParameters.ts
@@ -47,7 +47,7 @@ export default class TaskParameters {
     public distImageTags: string = "";
 
     constructor() {
-        var locations = ["eastus", "eastus2", "westcentralus", "westus", "westus2", "southcentralus", "northeurope", "westeurope", "southeastasia", "australiasoutheast", "australia", "uksouth", "ukwest" ];
+        var locations = ["eastus", "eastus2", "westcentralus", "westus", "westus2", "westus3", "southcentralus", "northeurope", "westeurope", "southeastasia", "australiasoutheast", "australiaeast", "uksouth", "ukwest", "brazilsouth", "canadacentral", "centralindia", "centralus", "francecentral", "germanywestcentral", "japaneast", "northcentralus", "norwayeast", "switzerlandnorth", "jioindiawest", "uaenorth", "eastasia", "koreacentral", "southafricanorth", "usgovarizona", "usgovvirginia"];
 
         console.log("start reading task parameters...");
 


### PR DESCRIPTION
This PR updates the action's parameter validation to resync the allowed location list with the [list in the product documentation](https://learn.microsoft.com/azure/virtual-machines/image-builder-overview?tabs=azure-powershell#regions).